### PR TITLE
Outdated dependencies syntax 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
- {lager,   "2.*", {git, "https://github.com/basho/lager.git", "master"}},
+ {lager,   "2.*", {git, "https://github.com/basho/lager.git", {branch, "master"}}},
  {eper,    "0.*", {git, "https://github.com/massemanet/eper.git", {branch, "master"}}},
  {emysql,  "0.*", {git, "https://github.com/Eonblast/Emysql.git", {branch, "master"}}},
  {cowboy,  "0.*", {git, "https://github.com/extend/cowboy.git", {branch, "master"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,11 @@
 {deps, [
- {lager,   "2.*", {git, "git@github.com:basho/lager.git",     "master"}},
- {eper,    "0.*", {git, "git@github.com:massemanet/eper.git", "master"}},
- {emysql,  "0.*", {git, "git@github.com:Eonblast/Emysql.git", "master"}},
- {cowboy,  "0.*", {git, "git@github.com:extend/cowboy.git",   "master"}},
- {jiffy,   "0.*", {git, "git@github.com:davisp/jiffy.git",    "master"}},
- {sumo_db, "1",   {git, "git@github.com:inaka/sumo_db.git",   "master"}}
+ {lager,   "2.*", {git, "https://github.com/basho/lager.git", "master"}},
+ {eper,    "0.*", {git, "https://github.com/massemanet/eper.git", {branch, "master"}}},
+ {emysql,  "0.*", {git, "https://github.com/Eonblast/Emysql.git", {branch, "master"}}},
+ {cowboy,  "0.*", {git, "https://github.com/extend/cowboy.git", {branch, "master"}}},
+ {jiffy,   "0.*", {git, "https://github.com/davisp/jiffy.git", {branch, "master"}}},
+ {sumo_db, "1",   {git, "https://github.com/inaka/sumo_db.git", {branch, "master"}}}
 ]}.
+
+
+

--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,10 @@
 {deps, [
- {lager,   "2.*", {git, "https://github.com/basho/lager.git", {branch, "master"}}},
- {eper,    "0.*", {git, "https://github.com/massemanet/eper.git", {branch, "master"}}},
- {emysql,  "0.*", {git, "https://github.com/Eonblast/Emysql.git", {branch, "master"}}},
- {cowboy,  "0.*", {git, "https://github.com/extend/cowboy.git", {branch, "master"}}},
- {jiffy,   "0.*", {git, "https://github.com/davisp/jiffy.git", {branch, "master"}}},
- {sumo_db, "1",   {git, "https://github.com/inaka/sumo_db.git", {branch, "master"}}}
+ {lager,   "2.*", {git, "git://github.com/basho/lager.git", {branch, "master"}}},
+ {eper,    "0.*", {git, "git://github.com/massemanet/eper.git", {branch, "master"}}},
+ {emysql,  "0.*", {git, "git://github.com/Eonblast/Emysql.git", {branch, "master"}}},
+ {cowboy,  "0.*", {git, "git://github.com/extend/cowboy.git", {branch, "master"}}},
+ {jiffy,   "0.*", {git, "git://github.com/davisp/jiffy.git", {branch, "master"}}},
+ {sumo_db, "1",   {git, "git://github.com/inaka/sumo_db.git", {branch, "master"}}}
 ]}.
 
 


### PR DESCRIPTION
Fixed outdated dependecies syntax, still unable to get second-level inaka dependencies.